### PR TITLE
remove uselss scale options from example packs

### DIFF
--- a/common/src/main/resources/resourcepacks/avila-basic-example/data/avila-example/novoatlas/map_info/avila.json
+++ b/common/src/main/resources/resourcepacks/avila-basic-example/data/avila-example/novoatlas/map_info/avila.json
@@ -1,7 +1,5 @@
 {
     "starting_y": 6,
-    "horizontal_scale": 1,
-    "vertical_scale": 1,
     "height_map": "avila-example:avila",
     "surface_biomes": {
         "map": "avila-example:avila",

--- a/common/src/main/resources/resourcepacks/avila-cave-biome-example/data/avila-example/novoatlas/map_info/avila.json
+++ b/common/src/main/resources/resourcepacks/avila-cave-biome-example/data/avila-example/novoatlas/map_info/avila.json
@@ -1,7 +1,5 @@
 {
     "starting_y": 6,
-    "horizontal_scale": 1,
-    "vertical_scale": 1,
     "height_map": "avila-example:avila",
     "surface_biomes": {
         "map": "avila-example:avila",

--- a/common/src/main/resources/resourcepacks/avila-no-caves-example/data/avila-example/novoatlas/map_info/avila.json
+++ b/common/src/main/resources/resourcepacks/avila-no-caves-example/data/avila-example/novoatlas/map_info/avila.json
@@ -1,7 +1,5 @@
 {
     "starting_y": 6,
-    "horizontal_scale": 1,
-    "vertical_scale": 1,
     "height_map": "avila-example:avila",
     "surface_biomes": {
         "map": "avila-example:avila",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the "horizontal_scale" and "vertical_scale" properties from map configuration files across multiple resource packs. No other settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->